### PR TITLE
Add PlatformIO Library Registry manifest file

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "NewAskSin",
+  "keywords": "protocol, message, communication, rf, cc1101",
+  "description": "Library for HM compatible devices on base of Arduino Hardware",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/trilu2000/NewAskSin"
+  },
+  "exclude" : 
+  [
+    "docs",
+    "destillRegs",
+    "destillRegs2"
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}


### PR DESCRIPTION
Add library.json file. This allows the library to be used from within PlatformIO (see http://platformio.org/)
