### PR TITLE
Add new method AS::send_generic_event()

### DIFF
--- a/AS.cpp
+++ b/AS.cpp
@@ -282,6 +282,21 @@ void AS::sendSensor_event(uint8_t cnl, uint8_t burst, uint8_t *pL) {
 	stcPeer.active = 1;
 	// --------------------------------------------------------------------
 }
+void AS::send_generic_event(uint8_t cnl, uint8_t burst, uint8_t mTyp, uint8_t len, uint8_t *pL) {
+        // description --------------------------------------------------------
+        //                 reID      toID      BLL  Cnt  Val
+        // l> 0C 0A A4 41  23 70 EC  1E 7A AD  02   01   200
+        // do something with the information ----------------------------------
+	stcPeer.pL = pL;
+	stcPeer.lenPL = len;
+	stcPeer.cnl = cnl;
+	stcPeer.burst = burst;
+	stcPeer.bidi = 1; // depends on BLL, long didn't need ack
+	stcPeer.bidi = (isEmpty(MAID,3))?0:1;
+	stcPeer.mTyp = mTyp;
+	stcPeer.active = 1;
+	// --------------------------------------------------------------------
+}
 void AS::sendSensorData(void) {
 	//"53"          => { txt => "SensorData"  , params => {
 	//CMD => "00,2",

--- a/AS.h
+++ b/AS.h
@@ -108,6 +108,7 @@ class AS {
 	void sendClimateEvent(void);
 	void sendSetTeamTemp(void);
 	void sendWeatherEvent(void);
+	void send_generic_event(uint8_t cnl, uint8_t burst, uint8_t mTyp, uint8_t len, uint8_t *pL);
 
   private:		//---------------------------------------------------------------------------------------------------------
 

--- a/HAL.h
+++ b/HAL.h
@@ -17,7 +17,7 @@
 	#include <avr/sleep.h>
 	#include <avr/power.h>
 	#include <avr/wdt.h>
-	#include <avr/delay.h>
+	#include <util/delay.h>
 	#include <util/atomic.h>
 	#include <avr/eeprom.h>
 


### PR DESCRIPTION
Hi, I need to be able to send a generic event (i.e. an event type specific to my sensor which is not and will never be covered in class AS). For this I added a new method send_generic_event() to class AS.

Please check if I got the lenPL right, in sendSensor_event(), lenPL is set to 3 even though the AsksinNew_test example passes a pointer to a uint8_t[2] buffer as payload.
