### PR TITLE
Fix pairing blink

### DIFF
--- a/ConfButton.cpp
+++ b/ConfButton.cpp
@@ -99,7 +99,6 @@ void CB::poll(void) {
 		
 	} else if ((btn == 1) && (btnTmr.done() )) {	// button is not pressed for a longer time, check if the double flags timed out
 		//if (armFlg) dbg << "r\n";
-		if (dblLng) pHM->ld.set(nothing);
 		armFlg = lstSht = lstLng = lngRpt = dblLng = 0;
 
 	}

--- a/HAL_extern.h
+++ b/HAL_extern.h
@@ -87,7 +87,7 @@ uint8_t chkPCINT(uint8_t port, uint8_t pin) {
 	uint8_t prev = pcInt[port].prev & _BV(pin);
 
 	if ((cur == prev) || ( (getMillis() - pcInt[port].time) < DEBOUNCE )) {		// old and new bit is similar, or DEBOUNCE time is running
-		return (pcInt[port].cur & _BV(pin)) ? 1 : 0;
+		return (pcInt[port].prev & _BV(pin)) ? 1 : 0;
 	}
 
 	//if ( (getMillis() - pcInt[port].time) < DEBOUNCE ) {
@@ -96,15 +96,8 @@ uint8_t chkPCINT(uint8_t port, uint8_t pin) {
 
 	// detect rising or falling edge
 	//dbg << pcInt[port].cur << ' ' << pcInt[port].prev << ' ';
-	if (cur) {																	// pin is 1
-		pcInt[port].prev |= _BV(pin);											// set bit bit in prev
-		//dbg << "y3\n";
-		return 3;
-	} else {																	// pin is 0
-		//dbg << "y2\n";
-		pcInt[port].prev &= ~_BV(pin);											// clear bit in prev
-		return 2;
-	}
+	pcInt[port].prev = cur;														// remind current button state for further checks
+	return cur ? 3 : 2;															// cur high? then rising (3) otherwise falling (2)
 }
 
 
@@ -135,19 +128,16 @@ void    initConfKey(void) {
 
 //- -----------------------------------------------------------------------------------------------------------------------
 ISR (PCINT0_vect) {
-	pcInt[0].prev = pcInt[0].cur;
 	pcInt[0].cur = PINB;
 	pcInt[0].time = getMillis();
 	//dbg << "i1:" << PINB  << "\n";
 }
 ISR (PCINT1_vect) {
-	pcInt[1].prev = pcInt[1].cur;
 	pcInt[1].cur = PINC;
 	pcInt[1].time = getMillis();
 	//dbg << "i2:" << PINC << "\n";
 }
 ISR (PCINT2_vect) {
-	pcInt[2].prev = pcInt[2].cur;
 	pcInt[2].cur = PIND;
 	pcInt[2].time = getMillis();
 	//dbg << "i3:" << PIND  << "\n";

--- a/StatusLed.cpp
+++ b/StatusLed.cpp
@@ -27,9 +27,12 @@ void    LD::init(uint8_t leds, AS *ptrMain) {
 	pHM = ptrMain;
 	bLeds = leds;
 }
+
 void    LD::set(ledStat stat) {
 	if (!bLeds) return;																		// no led available, skip...
-	//dbg << "stat: " << stat << '\n';
+	#ifdef LD_DBG
+	dbg << "stat: " << stat << '\n';
+	#endif
 
 	ledRed(0);																				// new program starts, so switch leds off
 	ledGrn(0);
@@ -76,12 +79,16 @@ void	LD::poll(void) {
 	ledTmr.set(blinkPtr->pat[lCnt]*10);														// set the timer for next check up
 	if ((blinkPtr->led0) && (blinkPtr->pat[lCnt])) {
 		ledRed((lCnt % 2)^1);																	// set the led
-		//dbg << "lCnt:" << lCnt << " led0: " << ((lCnt % 2)^1) << '\n';
+		#ifdef LD_DBG
+		dbg << "lCnt:" << lCnt << " led0: " << ((lCnt % 2)^1) << '\n';
+		#endif
 	}
 	
 	if ((blinkPtr->led1) && (blinkPtr->pat[lCnt])) {
 		ledGrn((lCnt % 2)^1);
-		//dbg << "lCnt:" << lCnt  << " led1: " << ((lCnt % 2)^1) << '\n';
+		#ifdef LD_DBG
+		dbg << "lCnt:" << lCnt  << " led1: " << ((lCnt % 2)^1) << '\n';
+		#endif
 	}
 	lCnt++;																					// increase the pointer for the blink string
 
@@ -89,14 +96,17 @@ void	LD::poll(void) {
 	if (lCnt >= blinkPtr->len) {															// we are through the pattern 
 		if (blinkPtr->dur == 0) {															// we are in an endless loop
 			lCnt = 0;
-			//dbg << "lCnt 0\n";
+			#ifdef LD_DBG
+			dbg << "lCnt 0\n";
+			#endif
 		} else if (dCnt < blinkPtr->dur) {													// duration is not done
 			lCnt = 0;
 			dCnt++;
-			//dbg << "lCnt 0, dCnt++\n";
+			#ifdef LD_DBG
+			dbg << "lCnt 0, dCnt++\n";
+			#endif
 		} else {
 			set(nothing);
-
 		}
 	}
 }

--- a/StatusLed.h
+++ b/StatusLed.h
@@ -60,8 +60,8 @@ enum ledStat {nothing, pairing, pair_suc, pair_err, send, ack, noack, bat_low, d
 		{6, 1, 0, 1, {10, 10, 50, 10, 50, 100} },
 	};
 	const struct s_blinkPattern sKeyLong[2] = {		// 10; key long indicator
-		{2, 0, 1, 0, {20, 20, } },
-		{2, 0, 1, 0, {20, 20, } },
+		{2, 6, 1, 0, {20, 20, } },
+		{2, 6, 1, 0, {20, 20, } },
 	};
 
 


### PR DESCRIPTION
Hallo trilu,

hier noch ein weitere Anpassung bzgl. des LED-Blinkens beim Pairing. Die LED hatte nur zwei Mal geblinkt. verantwortlich dafür ist Zeile 102 in ConfButton.cpp.
Die habe ich jetzt rausgelöscht - hatte dann den Nebeneffekt, daß das Key-Long Blinken endlos war. Deshalb habe ich das Blinken dort nun auf 6x beschränkt.
Hat das Löschen der Zeile evtl. sonst noch Nebenwirkungen, die zu berücksichtigen wären?

Martin
