### PR TITLE
Structure size

### DIFF
--- a/ConfButton.cpp
+++ b/ConfButton.cpp
@@ -38,7 +38,7 @@ void CB::poll(void) {
 	if (!scn) return;																		// mode not set, nothing to do
 	
 	// 0 for button is pressed, 1 for released, 2 for falling and 3 for rising edge
-	btn = chkPCINT(pciByte, pciBit);														// check input pin
+	btn = chkPCINT(pciByte, pciBit, 1);														// check input pin, do debouncing
 
 	if (btn == 2) {																			// button was just pressed
 		//dbg << "armed \n";

--- a/EEprom.cpp
+++ b/EEprom.cpp
@@ -129,7 +129,7 @@ void     EE::init(void) {
 	uint16_t eepromCRC = 0, flashCRC = 0;												// define variable for storing crc
 	uint8_t  *p = (uint8_t*)cnlTbl;														// cast devDef to char
 
-	for (uint8_t i = 0; i < (devDef.lstNbr*6); i++) {									// step through all bytes of the channel table, one line has 6 byte
+	for (uint8_t i = 0; i < (devDef.lstNbr*sizeof(s_cnlTbl)); i++) {					// step through all bytes of the channel table
 		flashCRC = crc16(flashCRC, p[i]);												// calculate the 16bit checksum for the table
 	}
 	getEEPromBlock(0,2,(void*)&eepromCRC);												// get magic byte from eeprom

--- a/HAL.h
+++ b/HAL.h
@@ -118,7 +118,7 @@
 	#define regPCINT(MASK,PORT)   (MASK  |= _BV(PORT))
 
 	extern void    initPCINT(void);
-	extern uint8_t chkPCINT(uint8_t port, uint8_t pin);
+	extern uint8_t chkPCINT(uint8_t port, uint8_t pin, uint8_t debounce);
 	//- -----------------------------------------------------------------------------------------------------------------------
 
 

--- a/HAL_extern.h
+++ b/HAL_extern.h
@@ -96,8 +96,15 @@ uint8_t chkPCINT(uint8_t port, uint8_t pin) {
 
 	// detect rising or falling edge
 	//dbg << pcInt[port].cur << ' ' << pcInt[port].prev << ' ';
-	pcInt[port].prev = cur;														// remind current button state for further checks
-	return cur ? 3 : 2;															// cur high? then rising (3) otherwise falling (2)
+	if (cur) {																	// pin is 1
+		pcInt[port].prev |= _BV(pin);											// set bit bit in prev
+		//dbg << "y3\n";
+		return 3;
+	} else {																	// pin is 0
+		//dbg << "y2\n";
+		pcInt[port].prev &= ~_BV(pin);											// clear bit in prev
+		return 2;
+	}
 }
 
 

--- a/HAL_extern.h
+++ b/HAL_extern.h
@@ -16,7 +16,7 @@ uint8_t ccSendByte(uint8_t data) {
 	return SPDR;
 }
 uint8_t ccGetGDO0() {
-	uint8_t x = chkPCINT(CC_GDO0_PCIE, CC_GDO0_INT);
+	uint8_t x = chkPCINT(CC_GDO0_PCIE, CC_GDO0_INT, 0);							// check PCINT without debouncing
 	//if (x>1) dbg << "x:" << x << '\n';
 
 	if (x == 2 ) return 1;														// falling edge detected
@@ -80,13 +80,13 @@ void    initPCINT(void) {
 	memset((uint8_t*)pcInt, 0x00, sizeof(pcInt));
 	//dbg << "a: " << pcInt[2].cur << '\n';
 }
-uint8_t chkPCINT(uint8_t port, uint8_t pin) {
+uint8_t chkPCINT(uint8_t port, uint8_t pin, uint8_t debounce) {
 	// returns pin status while no interrupt had happened for the pin, 2 for falling and 3 for rising edge
 
 	uint8_t cur  = pcInt[port].cur  & _BV(pin);
 	uint8_t prev = pcInt[port].prev & _BV(pin);
 
-	if ((cur == prev) || ( (getMillis() - pcInt[port].time) < DEBOUNCE )) {		// old and new bit is similar, or DEBOUNCE time is running
+	if ((cur == prev) || (debounce && ((getMillis() - pcInt[port].time) < DEBOUNCE ))) {		// old and new bit is similar, or DEBOUNCE time is running
 		return (pcInt[port].prev & _BV(pin)) ? 1 : 0;
 	}
 


### PR DESCRIPTION
Hallo Horst,

noch eine Korrektur: in EEprom.cpp war die Größe einer Struktur in einer Berechnung fix mit 6 Byte verankert. Die Größe hat sich aber auf 7 Byte erhöht (bitte kontrollier's noch mal!). Dementsprechend habe ich jetzt die Berechnung der Größe mit einem "sizeof" realisiert.

Wie ist denn eigentlich der Status der Lib? Ich finde an einigen Stellen noch viel auskommentierten Code... Funktionen, die (noch?) nichts tun.
So habe ich bei meinem Sensor mal Code für ein Weather-Event reingebaut...

Dieses Weather-Event z.B. sendet ja gar nicht auf einem Channel, sondern broadcastet die Daten lediglich raus (hab mal einen virtuellen Sensor in fhem konfiguriert). Ich wollte eigentlich für zwei Peers auf zwei verschiedenen Kanälen unterschiedlich kalibrierte Sensordaten rausschicken - scheint so aber nicht zu gehen...

Viele Grüße,
Martin
