### PR TITLE
add WeatherEvent, fix peer timing, uart timing

### DIFF
--- a/AS.cpp
+++ b/AS.cpp
@@ -46,6 +46,8 @@ void AS::init(void) {
 		dbg << F("AS.\n");																		// ...and some information
 	#endif
 
+	calibrateWatchdog();																		// calibrate the watchdog frequency (in relation to main clock)
+	//dbg << F("wdt_cal: ") << wdt_cal_ms << F("\n");
 	initLeds();																					// initialize the leds
 	initConfKey();																				// initialize the port for getting config key interrupts
 
@@ -61,8 +63,6 @@ void AS::init(void) {
 	confButton.init(this);																		// config button
 	pw.init(this);																				// power management
 	bt.init(this);																				// battery check
-	
-	initMillis();																				// start the millis counter
 
 	initRandomSeed();
 

--- a/AS.cpp
+++ b/AS.cpp
@@ -525,11 +525,10 @@ inline void AS::sendSliceList(void) {
 
 inline void AS::sendPeerMsg(void) {
 	uint8_t retries_max;
-	static waitTimer next_peer;
 
 	retries_max = (stcPeer.bidi) ? 3 : 1;
 	
-	if (sn.active || !next_peer.done()) return;													// check if send function has a free slot, otherwise return
+	if (sn.active) return;																		// check if send function has a free slot, otherwise return
 	
 	// first run, prepare amount of slots
 	if (!stcPeer.idx_max) {
@@ -602,8 +601,6 @@ inline void AS::sendPeerMsg(void) {
 	//l4_0x01.ui = 0;		// disable burst - hardcoded
 	
 	preparePeerMessage(tmp_peer, 1);
-	next_peer.set(100);																			// wait 100ms before sending message to next peer
-	pw.stayAwake(120);																			// keep cpu active to get exact timing
 	
 	if (!sn.mBdy.mFlg.BIDI) {
 		stcPeer.slot[stcPeer.idx_cur >> 3] &=  ~(1<<(stcPeer.idx_cur & 0x07));					// clear bit, because it is a message without need to be repeated

--- a/AS.h
+++ b/AS.h
@@ -153,7 +153,7 @@ class AS {
 	void sendSensorData(void);
 	void sendClimateEvent(void);
 	void sendSetTeamTemp(void);
-	void sendWeatherEvent(void);
+	void sendWeatherEvent(uint8_t cnl, uint8_t burst, uint8_t *pL, uint8_t len);
 	void sendEvent(uint8_t channel, uint8_t msg_type, uint8_t msg_flag, uint8_t *ptr_payload, uint8_t len_payload);
 
 	void processMessageConfigAction(uint8_t by10, uint8_t cnl1);

--- a/CC1101.cpp
+++ b/CC1101.cpp
@@ -128,12 +128,9 @@ uint8_t CC::sndData(uint8_t *buf, uint8_t burst) {										// send data packet 
 	strobe(CC1101_SFRX);																// flush the RX buffer
 	strobe(CC1101_STX);																	// send a burst
 
-	for(uint8_t i = 0; i < 200; i++) {													// after sending out all bytes the chip should go automatically in RX mode
-		if( readReg(CC1101_MARCSTATE, CC1101_STATUS) == MARCSTATE_RX)
+	for(uint16_t i = 0; i < 2000; i++) {												// after sending out all bytes the chip should go automatically in IDLE mode
+		if( readReg(CC1101_MARCSTATE, CC1101_STATUS) == MARCSTATE_IDLE)
 			break;																		//now in RX mode, good
-		if( readReg(CC1101_MARCSTATE, CC1101_STATUS) != MARCSTATE_TX) {
-			break;																		//neither in RX nor TX, probably some error
-		}
 		_delay_us(10);
 	}
 

--- a/CC1101.cpp
+++ b/CC1101.cpp
@@ -63,7 +63,7 @@ void    CC::init(void) {																// initialize CC1101
 		CC1101_MDMCFG2,  0x03,
 		CC1101_DEVIATN,  0x34,													// 19.042969 kHz
 		CC1101_MCSM2,    0x01,
-//		CC1101_MCSM1,    0x30,	// (default)									// always go into IDLE
+		CC1101_MCSM1,    0x03,													// always go into RX after TX, no CCA
 		CC1101_MCSM0,    0x18,
 		CC1101_FOCCFG,   0x16,
 		CC1101_AGCCTRL2, 0x43,
@@ -128,7 +128,13 @@ uint8_t CC::sndData(uint8_t *buf, uint8_t burst) {										// send data packet 
 	strobe(CC1101_SFRX);																// flush the RX buffer
 	strobe(CC1101_STX);																	// send a burst
 
-	for(uint16_t i = 0; i < 2000; i++) {												// after sending out all bytes the chip should go automatically in IDLE mode
+	for(uint8_t i = 0; i < 200; i++) {													// wait for end of calibration (about 600us) and entering state TX
+		if( readReg(CC1101_MARCSTATE, CC1101_STATUS) == MARCSTATE_TX)
+		break;
+		_delay_us(10);
+	}
+	// now transmitting data
+	for(uint16_t i = 0; i < 2000; i++) {												// after sending out all bytes the chip should go automatically in RX mode
 		if( readReg(CC1101_MARCSTATE, CC1101_STATUS) != MARCSTATE_TX)					// wait for end of transmit
 			break;
 		_delay_us(10);

--- a/CC1101.cpp
+++ b/CC1101.cpp
@@ -129,8 +129,8 @@ uint8_t CC::sndData(uint8_t *buf, uint8_t burst) {										// send data packet 
 	strobe(CC1101_STX);																	// send a burst
 
 	for(uint16_t i = 0; i < 2000; i++) {												// after sending out all bytes the chip should go automatically in IDLE mode
-		if( readReg(CC1101_MARCSTATE, CC1101_STATUS) == MARCSTATE_IDLE)
-			break;																		//now in RX mode, good
+		if( readReg(CC1101_MARCSTATE, CC1101_STATUS) != MARCSTATE_TX)					// wait for end of transmit
+			break;
 		_delay_us(10);
 	}
 

--- a/HAL.h
+++ b/HAL.h
@@ -154,7 +154,7 @@
 
 
 	//- power management functions --------------------------------------------------------------------------------------------
-	extern tMillis wdt_cal_ms;
+	extern uint16_t wdt_cal_ms;
 	extern void    startWDG32ms(void);
 	extern void    startWDG64ms(void);
 	extern void    startWDG250ms(void);

--- a/HAL.h
+++ b/HAL.h
@@ -20,6 +20,7 @@
 	#include <util/delay.h>
 	#include <util/atomic.h>
 	#include <avr/eeprom.h>
+	#include <avr/common.h>
 
 	#include "Print.h"
 
@@ -153,12 +154,14 @@
 
 
 	//- power management functions --------------------------------------------------------------------------------------------
+	extern tMillis wdt_cal_ms;
 	extern void    startWDG32ms(void);
 	extern void    startWDG64ms(void);
 	extern void    startWDG250ms(void);
 	extern void    startWDG8000ms(void);
 	extern void    setSleep(void);
 
+	extern void    calibrateWatchdog();
 	extern void    startWDG();
 	extern void    stopWDG();
 	extern void    setSleepMode();

--- a/Power.cpp
+++ b/Power.cpp
@@ -131,7 +131,7 @@ void PW::poll(void) {
 		stopWDG();																			// stop the watchdog
 	}
 
-	stayAwake(6);																			// stay awake for a very short time to get things done
+	//stayAwake(6);																			// stay awake for a very short time to get things done
 	
 	#ifdef PW_DBG																			// only if pw debug is set
 	dbg << ':';// << (getMillis() -fTme) << '\n';												// ...and some information

--- a/Power.cpp
+++ b/Power.cpp
@@ -64,12 +64,12 @@ void PW::poll(void) {
 	if (checkWakeupPin()) return;															// wakeup pin active
 	
 	// some communication still active, jump out
-	if ((pHM->sn.active) || (pHM->stcSlice.active) || (pHM->cFlag.active) || (pHM->pairActive) || (pHM->confButton.armFlg)) return;
+	if ((pHM->sn.active) || (pHM->stcSlice.active) || (pHM->stcPeer.active) || (pHM->cFlag.active) || (pHM->pairActive) || (pHM->confButton.armFlg)) return;
 	
 	#ifdef PW_DBG																			// only if pw debug is set
 	dbg << '.';																				// ...and some information
 	_delay_ms(1);
-	uint32_t fTme = getMillis();
+	//uint32_t fTme = getMillis();
 	#endif
 
 
@@ -117,6 +117,10 @@ void PW::poll(void) {
 
 	// todo: move sei() to setSleep() before sleep_cpu();
 	sei();
+
+	#ifdef PW_DBG
+	_delay_ms(1);																			// give UART some time to send last chars
+	#endif
 
 	setSleep();																				// call sleep function in HAL
 

--- a/Power.cpp
+++ b/Power.cpp
@@ -64,7 +64,7 @@ void PW::poll(void) {
 	if (checkWakeupPin()) return;															// wakeup pin active
 	
 	// some communication still active, jump out
-	if ((pHM->sn.active) || (pHM->stcSlice.active) || (pHM->stcPeer.active) || (pHM->cFlag.active) || (pHM->pairActive) || (pHM->confButton.armFlg)) return;
+	if ((pHM->sn.active) || (pHM->stcSlice.active) || (pHM->cFlag.active) || (pHM->pairActive) || (pHM->confButton.armFlg)) return;
 	
 	#ifdef PW_DBG																			// only if pw debug is set
 	dbg << '.';																				// ...and some information

--- a/Receive.cpp
+++ b/Receive.cpp
@@ -44,6 +44,7 @@ void	RV::poll(void) {
 	// some debugs
 	#ifdef RV_DBG																			// only if AS debug is set
 		dbg << (char)bIntend << F("> ") << _HEX(this->buf, this->bufLen) << ' ' << _TIME << '\n';
+		_delay_ms(10);
 	#endif
 
 	#ifdef RV_DBG_EX																		// only if extended AS debug is set

--- a/Send.cpp
+++ b/Send.cpp
@@ -92,6 +92,7 @@ void SN::poll(void) {
 		
 		#ifdef SN_DBG																		// only if AS debug is set
 			dbg << _HEX(this->buf, sndLen) << ' ' << _TIME << '\n';
+			_delay_ms(10);
 		#endif
 
 	} else if ((this->retrCnt >= this->maxRetr) && (sndTmr.done() )) {						// max retries achieved, but seems to have no answer
@@ -108,7 +109,8 @@ void SN::poll(void) {
 		pHM->ld.set(noack);
 		
 		#ifdef SN_DBG																		// only if AS debug is set
-		dbg << F("  timed out") << ' ' << _TIME << '\n';
+			dbg << F("  timed out") << ' ' << _TIME << '\n';
+			_delay_ms(5);
 		#endif
 	}
 


### PR DESCRIPTION
added sendWeatherEvent - sending TH infos to HM-CC-RT-DN now possible
fixed multiple peer sends - sending a message to multiple peers must have some delay between sends
no switch to power save mode when stcPeer.active (peer msg will be sent out immediately)
some fixes for debug messages: added delay to allow uart sending all chars

Hallo Dirk, hallo Horst,

ich habe wieder ein paar Fixes.
Insbesondere habe ich jetzt die Funktion sendWeatherEvent mit Leben gefüllt. Ein ACK von den Peers wird dabei nicht angefordert (war problematisch bei mehreren Peers). Bei mehreren Peers werden die Messages verzögert rausgesendet. Ein unmittelbares Senden der Messages nacheinander führte dazu, daß niemand (nicht einmal mehr die Zentrale) Messages erhielt. Vielleicht war auch schon der Sendevorgang "gestört".

Viele Grüße,
Martin
